### PR TITLE
Cleanup orientation hook listener

### DIFF
--- a/packages/react-device-orientation-hook/src/index.ts
+++ b/packages/react-device-orientation-hook/src/index.ts
@@ -32,7 +32,7 @@ const useOrientation = (initialState: IOrientationState = defaultState) => {
     );
 
     return () => {
-      window.addEventListener(
+      window.removeEventListener(
         'orientationchange',
         onOrientationChangeEvent,
         true,


### PR DESCRIPTION
Fix typo replacing `addEventListener` with `removeEventListener`

Closes #6 